### PR TITLE
Add Argo CD Installation and Configuration Script for GitOps Workflow

### DIFF
--- a/k8s/argocd.md
+++ b/k8s/argocd.md
@@ -1,0 +1,40 @@
+## Argo CD Installation and Setup
+
+For a streamlined GitOps setup, `PipeDreams` uses **Argo CD** to manage and synchronize application deployments in Kubernetes. The `install_argocd.sh` script automates the installation and configuration of Argo CD, as well as setting up `PipeDreams` as an Argo CD-managed application.
+
+### Script Overview
+
+The `install_argocd.sh` script performs the following steps:
+
+1. **Installs Argo CD** in the Kubernetes cluster.
+2. **Waits** for the Argo CD components to be fully ready.
+3. **Sets up port forwarding** for local access to the Argo CD UI at `https://localhost:8080`.
+4. **Retrieves the initial Argo CD admin password** from Kubernetes secrets, logs into Argo CD, and updates the password.
+5. **Configures the Argo CD Application** for `PipeDreams`, setting it to sync automatically with the GitHub repository.
+
+### Usage of `install_argocd.sh`
+
+To use the script, follow these steps:
+
+1. **Ensure Minikube is running** with `minikube start` and that `kubectl` is configured to use the Minikube context.
+2. **Execute the script** in the terminal:
+
+   ```bash
+   ./install_argocd.sh
+   ```
+
+3. **Script Output**:
+   - The script will install Argo CD, log in, and configure the `PipeDreams` application to sync from the GitHub repository.
+   - Once complete, access Argo CD’s UI at [https://localhost:8080](https://localhost:8080), using `admin` as the username and the updated password specified in the script.
+
+### Important Notes
+
+- **Port Forwarding**: The script sets up port forwarding to `localhost:8080` for accessing the Argo CD UI. To stop the port forwarding, use the command:
+
+  ```bash
+  kill %1
+  ```
+
+- **Auto-Sync with GitHub**: The `PipeDreams` application is configured in Argo CD with auto-sync enabled. Any updates pushed to the repository will trigger an automatic deployment in the Kubernetes cluster.
+
+By integrating Argo CD, this setup enables a fully automated GitOps workflow, where `PipeDreams` is continuously deployed from source code to production. This approach helps streamline operations, increase deployment speed, and maintain version control for Kubernetes resources.

--- a/k8s/install_argocd.sh
+++ b/k8s/install_argocd.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Set Argo CD namespace and application variables
+NAMESPACE="argocd"
+APP_NAME="pipedreams"
+REPO_URL="https://github.com/markjacksonfishing/pipedreams.git"
+REPO_PATH="k8s"  # Path within the repo where YAML files are stored
+
+# Step 1: Install Argo CD
+echo "Installing Argo CD in namespace $NAMESPACE..."
+kubectl create namespace $NAMESPACE
+kubectl apply -n $NAMESPACE -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+# Step 2: Wait for Argo CD components to be ready
+echo "Waiting for Argo CD components to be ready..."
+kubectl wait --for=condition=available --timeout=600s deployment/argocd-server -n $NAMESPACE
+
+# Step 3: Set up port forwarding and add a brief delay
+echo "Setting up port forwarding to access Argo CD UI on https://localhost:8080"
+kubectl port-forward svc/argocd-server -n $NAMESPACE 8080:443 > /dev/null 2>&1 &
+sleep 5  # Brief delay to ensure port forwarding is ready
+
+# Step 4: Retrieve initial admin password and login to Argo CD CLI
+echo "Retrieving initial Argo CD admin password..."
+ARGOCD_PWD=$(kubectl get secret argocd-initial-admin-secret -n $NAMESPACE -o jsonpath="{.data.password}" | base64 -d)
+
+echo "Logging into Argo CD with initial password..."
+argocd login localhost:8080 --username admin --password "$ARGOCD_PWD" --insecure || { echo "Login failed with initial password"; exit 1; }
+
+# Step 5: Change the Argo CD admin password and verify
+NEW_PASSWORD="mynewpassword"  # Change this to a secure password
+echo "Setting new Argo CD admin password..."
+argocd account update-password --current-password "$ARGOCD_PWD" --new-password "$NEW_PASSWORD"
+
+# Verify new password by logging in
+echo "Verifying new password..."
+if argocd login localhost:8080 --username admin --password "$NEW_PASSWORD" --insecure; then
+    echo "Password updated and verified successfully."
+else
+    echo "Password update verification failed."
+    exit 1
+fi
+
+# Step 6: Wait for Argo CD repository server to be ready
+echo "Waiting for Argo CD repository server to be ready..."
+kubectl wait --for=condition=available --timeout=600s deployment/argocd-repo-server -n $NAMESPACE
+
+# Step 7: Create Argo CD Application for GitOps
+echo "Creating Argo CD application for $APP_NAME from repo $REPO_URL..."
+argocd app create $APP_NAME \
+    --repo $REPO_URL \
+    --path $REPO_PATH \
+    --dest-server https://kubernetes.default.svc \
+    --dest-namespace pipedreams \
+    --sync-policy auto
+
+echo "Argo CD setup complete. Access the UI at https://localhost:8080"
+echo "Login with username: admin and password: $NEW_PASSWORD"
+echo "To stop port forwarding, run 'kill %1'"


### PR DESCRIPTION
 This PR adds a script, `install_argocd.sh`, that streamlines the setup of Argo CD within a Kubernetes cluster. It automates the deployment of Argo CD, configures access, and registers the `PipeDreams` application for GitOps-driven deployment. This setup enables `PipeDreams` to be continuously deployed and updated in Kubernetes based on changes in the specified GitHub repository.
 
 Fixes #8 

#### Key Changes

1. **`install_argocd.sh` Script**:
   - Installs Argo CD in the specified Kubernetes namespace (`argocd`).
   - Waits for Argo CD server components to be ready before proceeding.
   - Sets up port forwarding to access the Argo CD UI locally on `https://localhost:8080`.
   - Retrieves the initial admin password from Kubernetes secrets and logs in with the Argo CD CLI.
   - Updates the default admin password to a specified new password.
   - Configures the `PipeDreams` application in Argo CD, setting it to automatically sync with the specified GitHub repository.

2. **Script Steps**:
   - **Namespace and Installation**: Creates the `argocd` namespace (if not already present) and installs Argo CD.
   - **Component Readiness Check**: Waits for the Argo CD server deployment to be fully available.
   - **Port Forwarding**: Sets up a background process for port forwarding to `localhost:8080`.
   - **Admin Password Configuration**: Retrieves the initial admin password, logs in, and updates it to a predefined new password.
   - **Application Registration**: Registers the `PipeDreams` application in Argo CD, pointing it to the specified GitHub repository and configuration path.

3. **Automated Access Details**:
   - The script outputs instructions to access Argo CD on `https://localhost:8080`, including login credentials.

#### Usage

1. **Run the Script**:
   - Ensure Minikube is running (`minikube start`), and `kubectl` is configured for the cluster.
   - Execute the script:

     ```bash
     ./install_argocd.sh
     ```

2. **Post-Execution**:
   - Access the Argo CD UI at [https://localhost:8080](https://localhost:8080).
   - Log in with the username `admin` and the new password specified in the script.

#### Additional Notes

- **GitOps-Driven Deployment**: The `PipeDreams` application is configured for auto-sync, meaning any updates pushed to the repository will automatically deploy to the Kubernetes cluster.
- **Port Forwarding Control**: Use `kill %1` to stop the port forwarding process after use.

This script simplifies the GitOps setup process by automating the deployment and configuration of Argo CD, allowing users to focus on application development and deployment. Let me know if you have any questions or further requirements for this setup.